### PR TITLE
Add context menu and copy action for password details text area.

### DIFF
--- a/Pass4Win/Main.Designer.cs
+++ b/Pass4Win/Main.Designer.cs
@@ -112,6 +112,7 @@
             this.copyPassDetailMenuItem});
             this.passDetailMenu.Name = "passDetailMenu";
             resources.ApplyResources(this.passDetailMenu, "passDetailMenu");
+            this.passDetailMenu.Opening += new System.ComponentModel.CancelEventHandler(this.passDetailMenu_Opening);
             // 
             // copyPassDetailMenuItem
             // 

--- a/Pass4Win/Main.Designer.cs
+++ b/Pass4Win/Main.Designer.cs
@@ -35,6 +35,8 @@
             this.statusPB = new System.Windows.Forms.ToolStripProgressBar();
             this.toolStripOffline = new System.Windows.Forms.ToolStripStatusLabel();
             this.txtPassDetail = new System.Windows.Forms.RichTextBox();
+            this.passDetailMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.copyPassDetailMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.dataPass = new System.Windows.Forms.DataGridView();
             this.dataMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -56,6 +58,7 @@
             this.toolStripBtnGenPass = new System.Windows.Forms.ToolStripButton();
             this.TextDelay = new System.Windows.Forms.Timer(this.components);
             this.statusPass.SuspendLayout();
+            this.passDetailMenu.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataPass)).BeginInit();
             this.dataMenu.SuspendLayout();
             this.SystrayMenu.SuspendLayout();
@@ -64,6 +67,7 @@
             // 
             // statusPass
             // 
+            this.statusPass.ImageScalingSize = new System.Drawing.Size(18, 18);
             this.statusPass.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.statusTxt,
             this.statusPB,
@@ -95,10 +99,25 @@
             // 
             // txtPassDetail
             // 
+            this.txtPassDetail.ContextMenuStrip = this.passDetailMenu;
             resources.ApplyResources(this.txtPassDetail, "txtPassDetail");
             this.txtPassDetail.Name = "txtPassDetail";
             this.txtPassDetail.ReadOnly = true;
             this.txtPassDetail.Leave += new System.EventHandler(this.txtPassDetail_Leave);
+            // 
+            // passDetailMenu
+            // 
+            this.passDetailMenu.ImageScalingSize = new System.Drawing.Size(18, 18);
+            this.passDetailMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.copyPassDetailMenuItem});
+            this.passDetailMenu.Name = "passDetailMenu";
+            resources.ApplyResources(this.passDetailMenu, "passDetailMenu");
+            // 
+            // copyPassDetailMenuItem
+            // 
+            this.copyPassDetailMenuItem.Name = "copyPassDetailMenuItem";
+            resources.ApplyResources(this.copyPassDetailMenuItem, "copyPassDetailMenuItem");
+            this.copyPassDetailMenuItem.Click += new System.EventHandler(this.copyPassDetailMenuItem_Click);
             // 
             // dataPass
             // 
@@ -125,6 +144,7 @@
             // 
             // dataMenu
             // 
+            this.dataMenu.ImageScalingSize = new System.Drawing.Size(18, 18);
             this.dataMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.copyToolStripMenuItem,
             this.editToolStripMenuItem,
@@ -174,6 +194,7 @@
             // 
             // SystrayMenu
             // 
+            this.SystrayMenu.ImageScalingSize = new System.Drawing.Size(18, 18);
             this.SystrayMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.openSystrayMenuItem,
             this.quitSystrayMenuItem});
@@ -195,6 +216,7 @@
             // toolStripSearch
             // 
             this.toolStripSearch.CanOverflow = false;
+            this.toolStripSearch.ImageScalingSize = new System.Drawing.Size(18, 18);
             this.toolStripSearch.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStriptextSearch,
             this.ToolStripbtnAdd,
@@ -284,6 +306,7 @@
             this.Resize += new System.EventHandler(this.frmMain_Resize);
             this.statusPass.ResumeLayout(false);
             this.statusPass.PerformLayout();
+            this.passDetailMenu.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.dataPass)).EndInit();
             this.dataMenu.ResumeLayout(false);
             this.SystrayMenu.ResumeLayout(false);
@@ -320,6 +343,8 @@
         private System.Windows.Forms.ToolStripButton toolStripbtnQuit;
         private System.Windows.Forms.Timer TextDelay;
         private System.Windows.Forms.ToolStripButton toolStripBtnGenPass;
+        private System.Windows.Forms.ContextMenuStrip passDetailMenu;
+        private System.Windows.Forms.ToolStripMenuItem copyPassDetailMenuItem;
     }
 }
 

--- a/Pass4Win/Main.cs
+++ b/Pass4Win/Main.cs
@@ -435,9 +435,7 @@ namespace Pass4Win
         private void editToolStripMenuItem_Click(object sender, EventArgs e)
         {
             // dispose timer thread and clear ui.
-            if (_timer != null) _timer.Dispose();
-            statusPB.Visible = false;
-            statusTxt.Text = "Ready";
+            KillTimer();
             // make control editable, give focus and content
             decrypt_pass(dataPass.Rows[dataPass.CurrentCell.RowIndex].Cells[0].Value.ToString(), false);
             txtPassDetail.ReadOnly = false;
@@ -910,10 +908,7 @@ namespace Pass4Win
                     repo.Stage(tmpPath);
                 }
                 // dispose timer thread and clear ui.
-
-                if (_timer != null) _timer.Dispose();
-                statusPB.Visible = false;
-                statusTxt.Text = "Ready";
+                KillTimer();
                 // Set the text detail to the correct state
                 txtPassDetail.Text = "";
                 txtPassDetail.ReadOnly = false;
@@ -969,11 +964,9 @@ namespace Pass4Win
             {
                 txtPassDetail.Clear();
                 // dispose timer thread and clear ui.
-                if (_timer != null) _timer.Dispose();
-                statusPB.Visible = false;
+                KillTimer();
                 // disable right click
                 dataMenu.Enabled = false;
-                statusTxt.Text = "Ready";
             }
             else
             {
@@ -984,10 +977,7 @@ namespace Pass4Win
 
         private void toolStripBtnGenPass_Click(object sender, EventArgs e)
         {
-            // Kill timer
-            if (_timer != null) _timer.Dispose();
-            statusPB.Visible = false;
-            statusTxt.Text = "Ready";
+            KillTimer();
 
             // Open Form
             Genpass frmGenpass = new Genpass();
@@ -997,6 +987,14 @@ namespace Pass4Win
         private void copyPassDetailMenuItem_Click(object sender, EventArgs e)
         {
             Clipboard.SetText(txtPassDetail.SelectedText);
+            KillTimer();
+        }
+
+        private void KillTimer()
+        {
+            if (_timer != null) _timer.Dispose();
+            statusPB.Visible = false;
+            statusTxt.Text = "Ready";
         }
     }
 

--- a/Pass4Win/Main.cs
+++ b/Pass4Win/Main.cs
@@ -993,6 +993,11 @@ namespace Pass4Win
             Genpass frmGenpass = new Genpass();
             frmGenpass.Show();
         }
+
+        private void copyPassDetailMenuItem_Click(object sender, EventArgs e)
+        {
+            Clipboard.SetText(txtPassDetail.SelectedText);
+        }
     }
 
     /// <summary>

--- a/Pass4Win/Main.cs
+++ b/Pass4Win/Main.cs
@@ -996,6 +996,11 @@ namespace Pass4Win
             statusPB.Visible = false;
             statusTxt.Text = "Ready";
         }
+
+        private void passDetailMenu_Opening(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            copyPassDetailMenuItem.Enabled = (txtPassDetail.SelectedText != null && txtPassDetail.SelectedText.Length > 0);
+        }
     }
 
     /// <summary>

--- a/Pass4Win/Main.resx
+++ b/Pass4Win/Main.resx
@@ -122,13 +122,13 @@
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="statusTxt.Size" type="System.Drawing.Size, System.Drawing">
-    <value>39, 17</value>
+    <value>46, 19</value>
   </data>
   <data name="statusTxt.Text" xml:space="preserve">
     <value>Ready</value>
   </data>
   <data name="statusPB.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 16</value>
+    <value>100, 18</value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="statusPB.Visible" type="System.Boolean, mscorlib">
@@ -138,7 +138,7 @@
     <value>Segoe UI, 9pt, style=Bold</value>
   </data>
   <data name="toolStripOffline.Size" type="System.Drawing.Size, System.Drawing">
-    <value>632, 17</value>
+    <value>625, 19</value>
   </data>
   <data name="toolStripOffline.Text" xml:space="preserve">
     <value>OFFLINE (click to sync)</value>
@@ -147,10 +147,10 @@
     <value>False</value>
   </data>
   <data name="statusPass.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 290</value>
+    <value>0, 288</value>
   </data>
   <data name="statusPass.Size" type="System.Drawing.Size, System.Drawing">
-    <value>686, 22</value>
+    <value>686, 24</value>
   </data>
   <data name="statusPass.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -168,7 +168,25 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;statusPass.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
+  </data>
+  <metadata name="passDetailMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>1140, 17</value>
+  </metadata>
+  <data name="copyPassDetailMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>165, 24</value>
+  </data>
+  <data name="copyPassDetailMenuItem.Text" xml:space="preserve">
+    <value>Copy</value>
+  </data>
+  <data name="passDetailMenu.Size" type="System.Drawing.Size, System.Drawing">
+    <value>166, 52</value>
+  </data>
+  <data name="&gt;&gt;passDetailMenu.Name" xml:space="preserve">
+    <value>passDetailMenu</value>
+  </data>
+  <data name="&gt;&gt;passDetailMenu.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="txtPassDetail.Location" type="System.Drawing.Point, System.Drawing">
     <value>370, 32</value>
@@ -195,37 +213,37 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;txtPassDetail.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <metadata name="dataMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>293, 17</value>
   </metadata>
   <data name="copyToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>117, 22</value>
+    <value>130, 24</value>
   </data>
   <data name="copyToolStripMenuItem.Text" xml:space="preserve">
     <value>Copy</value>
   </data>
   <data name="editToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>117, 22</value>
+    <value>130, 24</value>
   </data>
   <data name="editToolStripMenuItem.Text" xml:space="preserve">
     <value>Edit</value>
   </data>
   <data name="renameToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>117, 22</value>
+    <value>130, 24</value>
   </data>
   <data name="renameToolStripMenuItem.Text" xml:space="preserve">
     <value>Rename</value>
   </data>
   <data name="deleteToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>117, 22</value>
+    <value>130, 24</value>
   </data>
   <data name="deleteToolStripMenuItem.Text" xml:space="preserve">
     <value>Delete</value>
   </data>
   <data name="dataMenu.Size" type="System.Drawing.Size, System.Drawing">
-    <value>118, 92</value>
+    <value>131, 100</value>
   </data>
   <data name="&gt;&gt;dataMenu.Name" xml:space="preserve">
     <value>dataMenu</value>
@@ -252,7 +270,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;dataPass.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="btnMakeVisible.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
@@ -280,7 +298,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnMakeVisible.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <metadata name="notifyIcon1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>659, 17</value>
@@ -292,19 +310,19 @@
     <value>772, 17</value>
   </metadata>
   <data name="openSystrayMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>103, 22</value>
+    <value>115, 24</value>
   </data>
   <data name="openSystrayMenuItem.Text" xml:space="preserve">
     <value>Open</value>
   </data>
   <data name="quitSystrayMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>103, 22</value>
+    <value>115, 24</value>
   </data>
   <data name="quitSystrayMenuItem.Text" xml:space="preserve">
     <value>Quit</value>
   </data>
   <data name="SystrayMenu.Size" type="System.Drawing.Size, System.Drawing">
-    <value>104, 48</value>
+    <value>116, 52</value>
   </data>
   <data name="&gt;&gt;SystrayMenu.Name" xml:space="preserve">
     <value>SystrayMenu</value>
@@ -6502,7 +6520,7 @@
   <data name="ToolStripbtnAdd.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAB+SURBVFhHvc0xCsBAEMPA+/+nk1aFIFxAFkyzxfr86PmQ
+        YQUAAAAJcEhZcwAAEE0AABBNAWeMAeAAAAB+SURBVFhHvc0xCsBAEMPA+/+nk1aFIFxAFkyzxfr86PmQ
         Z6OUZ6OUZ6OUZ6OUZ6OUZ6OUZ6OUZ6OUZ6OUZ6OUZ6N0nT1Z0uOSHpf0uKTHJT0u6XFJj0vX2RPKs1HK
         s1HKs1HKs1HKs1HKs1HKs1HKs1HKs1HKs1HKs1G66JwXKXS+UGx3qqgAAAAASUVORK5CYII=
 </value>
@@ -6519,7 +6537,7 @@
   <data name="toolStripbtnQuit.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIbSURBVFhH7ZZJrw1BFIAvMexYWSDkESTiLxg2RGIhL6bE
+        YQUAAAAJcEhZcwAAEE0AABBNAWeMAeAAAAIbSURBVFhH7ZZJrw1BFIAvMexYWSDkESTiLxg2RGIhL6bE
         ChESW4mNja3hJ2AhRFi+n4CN8AcMsWZpiJiH73t0cpzq6nv7vo4NX/LlDn3qVHVX1ekaTcGP5F/n/wD+
         nQGs/P2ZGTeARbji19fp2YYv8Pz8rz8ZN4AL+By3zv+agj34Bk3+DfdhpGsA+/E7+r85zNULG3zC2MFr
         3IgN8Zo2bMK3GK+Za+JBbMacwLu5jEuwIV7XhmV4DfN1n4S5O1mMjzA2dPRHMBNjNHMWm2lofIj2UeU4
@@ -6543,7 +6561,7 @@
   <data name="toolStripbtnAbout.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAFQSURBVFhH7dY/KEZRGMfx689gEyXFYpEYWazKInaryWox
+        YQUAAAAJcEhZcwAAEE0AABBNAWeMAeAAAAFQSURBVFhH7dY/KEZRGMfx689gEyXFYpEYWazKInaryWox
         vAajZJJJSaGMFqOVLBYsQpSYGMiG/Ps+on6d3nLO8Z5jub/6DO+te57nvue5p1tEpAGjWMEhHvCKN9zj
         CGsYRxNqmjFc4sPTHSZRk8yiWhEfG6hHdCZQbeEQ9gBRaYHtsy5m+72OYbTB5sK0f19bxjP0nid0IDjT
         0IVeYLPwW/rhNj6D4OxBF1mAb6ag9+4gOPt4xM8ivfBNH7SBM0SnFQOo+/rll25oA+fImiFoA7vImjlo
@@ -6564,7 +6582,7 @@
   <data name="toolStripbtnConfig.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAImSURBVFhHvddNSxVRHMfxC2kZuFE00NqriKY9aBSFvoMI
+        YQUAAAAJcEhZcwAAEE0AABBNAWeMAeAAAAImSURBVFhHvddNSxVRHMfxC2kZuFE00NqriKY9aBSFvoMI
         xI0gvYZoUatEt1q0aBGJ1a7oHVSLaBPiW1Awo3xAwQTLBO37k3tkOvzPnLlxnB98kHvmnoeZO/8zY+U/
         M4BDz1WUltfwF/AKpaQVv+EvQG0tSJJ+PEHH0ad/8xD+5M4D+OmCxuo9+lQgmnwTGvAA73Ebp6Cz/wp/
         YmcZTdB37+Aj3LENRBfRBze5TxPvem2WHax4bY4W0YNgnsPqmNIzBHMZVqeULiI3X2B1TOEzohmD1TmF
@@ -6588,7 +6606,7 @@
   <data name="toolStripbtnKey.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAADuSURBVFhH7ZNLCsJAEESzUxSPoh5E9HR+8DDiJQTxJrpR
+        YQUAAAAJcEhZcwAAEE0AABBNAWeMAeAAAADuSURBVFhH7ZNLCsJAEESzUxSPoh5E9HR+8DDiJQTxJrpR
         qyFCM1YsxpQ7HzwIk67uzCRpvmAOd/ACb61xvYUz+DOGcA/v8NFh3NvAAbQSw4+QDWUeYGRsxM7ZoE/G
         SViId14e+wmu4ASO4KJdyzWRmcLexAeXG8egGFwSa+VDrGFv4gvPTWPnXSxhrj3D3sRvlpuy3b8Yw1x7
         hb3JDUNFbb2ktmFtvaS2YW29pLZhbf0bZQO3EhZyKmEhpxIWciphIacSFnIqYSGnEhZyKmEhpxIWciph
@@ -6607,7 +6625,7 @@
   <data name="toolStripBtnGenPass.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAFVSURBVFhHtdXfKgdBGMbxzQGFwoURiohciz83QCn3QFyO
+        YQUAAAAJcEhZcwAAEE0AABBNAWeMAeAAAAFVSURBVFhHtdXfKgdBGMbxzQGFwoURiohciz83QCn3QFyO
         5ICEY+WMA3yf8qu36d3ZmZ13n/qUg/m9z+zu7OqCsoAj3OEF3//09y0OoTWTZA/v+B3whl2EZQ5X8Mpy
         LqHfNmdM+Yw20RTddm/wzD3WsYglbOABds0ORkWHKffMVb6CNKuwm3jFPKqj024LU7ryvmzCrj1AdfSq
         2SEp3fa+LMOuvUF19G7bISk9876kG3hGdfSBsUNSOnB92YJd+4Xq2AEeHTQduDRreIRdO2oDn7BDPNqE
@@ -6644,7 +6662,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;toolStripSearch.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <metadata name="TextDelay.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>1029, 17</value>
@@ -12850,6 +12868,12 @@
   </data>
   <data name="&gt;&gt;toolStripOffline.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripStatusLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;copyPassDetailMenuItem.Name" xml:space="preserve">
+    <value>copyPassDetailMenuItem</value>
+  </data>
+  <data name="&gt;&gt;copyPassDetailMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;copyToolStripMenuItem.Name" xml:space="preserve">
     <value>copyToolStripMenuItem</value>

--- a/Pass4Win/Main.resx
+++ b/Pass4Win/Main.resx
@@ -174,13 +174,13 @@
     <value>1140, 17</value>
   </metadata>
   <data name="copyPassDetailMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>165, 24</value>
+    <value>113, 24</value>
   </data>
   <data name="copyPassDetailMenuItem.Text" xml:space="preserve">
     <value>Copy</value>
   </data>
   <data name="passDetailMenu.Size" type="System.Drawing.Size, System.Drawing">
-    <value>166, 52</value>
+    <value>114, 28</value>
   </data>
   <data name="&gt;&gt;passDetailMenu.Name" xml:space="preserve">
     <value>passDetailMenu</value>


### PR DESCRIPTION
This implements the enhancement proposed in issue #62.

The reasoning behind not using clipboard auto clear is that it is assumed that copying from the password details text area is an operation performed consciously by the user where the application should behave similar to regular text areas in other applications.

Consequently, copying from the details text area also cancels the ClearClipboard timer if it exists.
