### PR TITLE
Allow user to cancel configuration on first run

### DIFF
--- a/Pass4Win/KeySelect.cs
+++ b/Pass4Win/KeySelect.cs
@@ -35,7 +35,10 @@ namespace Pass4Win
             {
                 comboBox1.Items.Add(key.UserInfos[0].Email + "(" + key.Id + ")");
             }
-            comboBox1.SelectedIndex= 0;
+            if (comboBox1.Items.Count>0)
+            {
+                comboBox1.SelectedIndex = 0;
+            }
             TopMost = true;
         }
 

--- a/Pass4Win/config.cs
+++ b/Pass4Win/config.cs
@@ -323,10 +323,10 @@ namespace Pass4Win
         /// <param name="e"></param>
         private void FrmConfigFormClosing(object sender, FormClosingEventArgs e)
         {
-            this.valCancel = true;
-            if (!ValidateChildren()) e.Cancel = true;
-            OnSendOffline(null);
-            this.valCancel = false;
+            if ( (this.valCancel = _config["FirstRun"]) )
+                if (!ValidateChildren()) e.Cancel = true;
+                OnSendOffline(null);
+                this.valCancel = false;
         }
 
         /// <summary>


### PR DESCRIPTION
Came across this bug, making me have to terminate the process to close.

Please review the FormClosing event as this was a quick change.